### PR TITLE
fix: format resolve path in window

### DIFF
--- a/packages/ice-plugin-component/lib/utils/configBabel.js
+++ b/packages/ice-plugin-component/lib/utils/configBabel.js
@@ -1,3 +1,5 @@
+const formatPathForWin = require('../utils/formatPathForWin');
+
 /**
  * @param {class} config
  * @param {object} babelOpts
@@ -17,7 +19,7 @@ module.exports = function (config, babelOpts) {
           const list = (options[babelKey] || []).map((babelOption) => {
             const path = Array.isArray(babelOption) ? babelOption[0] : babelOption;
             // find target babel config and modify options
-            const targetConfig = configList.find(({ name }) => path.indexOf(name) > -1);
+            const targetConfig = configList.find(({ name }) => formatPathForWin(path).indexOf(name) > -1);
             if (targetConfig) {
               matchedConfig[babelKey].push(targetConfig.name);
               return [

--- a/packages/ice-plugin-component/lib/utils/formatPathForWin.js
+++ b/packages/ice-plugin-component/lib/utils/formatPathForWin.js
@@ -1,4 +1,4 @@
 module.exports = function formatPathForWin(filepath) {
   const isWin = process.platform === 'win32';
-  return isWin ? filepath.replace(/\\/g, '\\\\') : filepath;
+  return isWin ? filepath.replace(/\\/g, '/') : filepath;
 };

--- a/packages/ice-plugin-component/package.json
+++ b/packages/ice-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-plugin-component",
-  "version": "0.1.3",
+  "version": "0.1.4-1",
   "description": "ice plugin for develop component",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## 问题描述
window下 require.resolve 出来的路径为"\\" 识别babel配置判断的时候会出问题，导致 @babel/preset-env 配置无法按组件编译更新