### PR TITLE
ice-scripts/release 2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.8
+
+- [fix] add polyfill when entry path include node_modules
+
 ## 2.1.7
 
 - [fix] add polyfill when entry modified by plugin

--- a/packages/ice-scripts/lib/config/processEntry.js
+++ b/packages/ice-scripts/lib/config/processEntry.js
@@ -50,13 +50,18 @@ module.exports = (config, options = {}) => {
   if (options.polyfill) {
     const rule = config.module.rule('polyfill').test(/\.jsx?|\.tsx?$/);
     Object.keys(entries).forEach((key) => {
+      let addPolyfill = false;
       // only include entry path
       for (let i = 0; i < entries[key].length; i += 1) {
         // filter node_modules file add by plugin
         if (!/node_modules/.test(entries[key][i])) {
           rule.include.add(entries[key][i]);
+          addPolyfill = true;
           break;
         }
+      }
+      if (!addPolyfill) {
+        rule.include.add(entries[key][0]);
       }
     });
     rule.use('polyfill-loader').loader(require.resolve('../utils/polyfillLoader')).options({});

--- a/packages/ice-scripts/package.json
+++ b/packages/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
- [x] fix: add polyfill when entry path include node_modules