### PR TITLE
chore: remove index.js from packages/ice-scripts

### DIFF
--- a/packages/ice-scripts/index.js
+++ b/packages/ice-scripts/index.js
@@ -1,7 +1,0 @@
-const dev = require('./lib/dev');
-const build = require('./lib/build');
-
-module.exports = {
-  dev,
-  build,
-};


### PR DESCRIPTION
The entry point for `packages/ice-scripts` is `packages/ice-scripts/bin/ice-scripts.js` now, so we can remove the unnecessary file.