### PR TITLE
 fix: lock less version to 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.9
+
+- [fix] lock less verison to 3.9.0 less/less.js#3414
+
 ## 2.1.8
 
 - [fix] add polyfill when entry path include node_modules

--- a/packages/ice-scripts/package.json
+++ b/packages/ice-scripts/package.json
@@ -68,7 +68,7 @@
     "identity-obj-proxy": "^3.0.0",
     "inquirer": "^6.4.1",
     "jest": "^24.8.0",
-    "less": "^3.8.1",
+    "less": "~3.9.0",
     "less-loader": "^4.1.0",
     "lodash": "^4.17.11",
     "lodash.clonedeep": "^4.5.0",

--- a/packages/ice-scripts/package.json
+++ b/packages/ice-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-scripts",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "ICE SDK",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
less/less.js#3414