### PR TITLE
fix: deep copy babelConfig from webpack config

### DIFF
--- a/packages/ice-plugin-component/package.json
+++ b/packages/ice-plugin-component/package.json
@@ -21,6 +21,7 @@
     "ice-npm-utils": "^1.0.3",
     "js-yaml": "^3.13.1",
     "loader-utils": "^1.2.3",
+    "lodash.clonedeep": "^4.5.0",
     "marked": "^0.6.2",
     "npmlog": "^4.1.2",
     "prismjs": "^1.16.0",


### PR DESCRIPTION
fix: alibaba/ice#2724

### 问题原因
ice-plugin-component 在执行 lib 构建阶段需要重新获取 babelConfig，不然插件的执行顺序可能会影响到 babelConfig 的内容
babelConfig 获取尽量使用 deepclone 避免 side effect