### PR TITLE
feat: support option nextLibDir for change libraryDirectory

### DIFF
--- a/packages/ice-plugin-fusion/CHANGELOG.md
+++ b/packages/ice-plugin-fusion/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.12
+
+- [feat] support option nextLibDir for change libraryDirectory
+
 ## 0.1.11
 
 - [fix] problem with importing scss file paths on windows

--- a/packages/ice-plugin-fusion/lib/index.js
+++ b/packages/ice-plugin-fusion/lib/index.js
@@ -19,7 +19,7 @@ function normalizeEntry(entry, preparedChunks) {
 
 module.exports = async ({ chainWebpack, log, context }, plugionOptions) => {
   plugionOptions = plugionOptions || {};
-  const { themePackage, themeConfig } = plugionOptions;
+  const { themePackage, themeConfig, nextLibDir } = plugionOptions;
   let { uniteBaseComponent } = plugionOptions;
   const { rootDir, pkg, userConfig } = context;
 
@@ -142,7 +142,7 @@ module.exports = async ({ chainWebpack, log, context }, plugionOptions) => {
       style: true,
     }, {
       libraryName: '@alifd/next',
-      libraryDirectory: 'es',
+      libraryDirectory: nextLibDir || 'es',
       style: true,
     }];
     ['jsx', 'tsx'].forEach((rule) => {

--- a/packages/ice-plugin-fusion/package.json
+++ b/packages/ice-plugin-fusion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-plugin-fusion",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "ice-scripts plugin for fusion",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
### 背景
业务在开发过程中有需求统一引用 lib 目录文件，目前 Next 组件加载的目录固定为 es，通过 webpack-chain 定制 babel 配置的成本较高，开放指定 libraryDirectory 入口
