### PR TITLE
fix: assets output path of component demo

### DIFF
--- a/packages/ice-plugin-component/CHANGELOG.md
+++ b/packages/ice-plugin-component/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.11
+
+ - [fix] assets output path
+
 ## 0.1.10
 
  - [feat] generate declaration when compile ts

--- a/packages/ice-plugin-component/lib/configs/build.js
+++ b/packages/ice-plugin-component/lib/configs/build.js
@@ -17,7 +17,8 @@ module.exports = (config, { demos, markdownParser, rootDir }) => {
   config.output.publicPath('./');
   ['scss', 'scss-module', 'css', 'css-module', 'less', 'less-module', 'styl', 'styl-module'].forEach((rule) => {
     if (config.module.rules.get(rule)) {
-      config.module.rule(rule).use('MiniCssExtractPlugin.loader').tap(() => ({ publicPath: '../' }));
+      // css output path is '', set publicPath './'
+      config.module.rule(rule).use('MiniCssExtractPlugin.loader').tap(() => ({ publicPath: './' }));
     }
   });
   // add hbs loader

--- a/packages/ice-plugin-component/package.json
+++ b/packages/ice-plugin-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ice-plugin-component",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "ice plugin for develop component",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
组件构建 demo 是，css 资源输出在根目录下，因此 assets 资源的 publicPath 应为 './'