### PR TITLE
fix: fix devWatcher not working when ice-scripts dev --config is specified

### DIFF
--- a/packages/ice-scripts/lib/core/Context.js
+++ b/packages/ice-scripts/lib/core/Context.js
@@ -16,6 +16,7 @@ module.exports = class Context {
     this.commandArgs = args;
     this.rootDir = rootDir;
     this.pkg = getPkgData(this.rootDir);
+    this.iceConfigPath = this.getIceConfigPath();
     // get user config form ice.config.js
     this.userConfig = this.getUserConfig();
     this.plugins = this.getPlugins();
@@ -27,21 +28,23 @@ module.exports = class Context {
     this.applyHook = this.applyHook.bind(this);
   }
 
-  getUserConfig() {
+  getIceConfigPath() {
+    let iceConfigPath = path.resolve(this.rootDir, 'ice.config.js');
     const { config } = this.commandArgs;
-    let iceConfigPath = '';
     if (config) {
       iceConfigPath = path.isAbsolute(config) ? config : path.resolve(this.rootDir, config);
-    } else {
-      iceConfigPath = path.resolve(this.rootDir, 'ice.config.js');
     }
+    return iceConfigPath;
+  }
+
+  getUserConfig() {
     let userConfig = {};
-    if (fse.existsSync(iceConfigPath)) {
+    if (fse.existsSync(this.iceConfigPath)) {
       try {
         // eslint-disable-next-line import/no-dynamic-require
-        userConfig = require(iceConfigPath);
+        userConfig = require(this.iceConfigPath);
       } catch (err) {
-        log.error(`Fail to load config file ${iceConfigPath}, use default config instead`);
+        log.error(`Fail to load config file ${this.iceConfigPath}, use default config instead`);
         console.error(err);
         process.exit(1);
       }

--- a/packages/ice-scripts/lib/plugins/devWatcher/index.js
+++ b/packages/ice-scripts/lib/plugins/devWatcher/index.js
@@ -1,24 +1,22 @@
-const path = require('path');
 const chokidar = require('chokidar');
 
 let server = null;
 let watcher = null;
 
 module.exports = ({ onHook, log, context }) => {
-  const { command, rootDir } = context;
+  const { command, iceConfigPath, commandArgs } = context;
   // watch ice.config.js in dev mode
   if (command === 'dev') {
     // setup watch
     // check watcher in case of reRun plugins
     if (!watcher) {
-      const configPath = path.resolve(rootDir, 'ice.config.js');
-      watcher = chokidar.watch(configPath, {
+      watcher = chokidar.watch(iceConfigPath, {
         ignoreInitial: true,
       });
 
       const onUserChange = () => {
         console.log('\n');
-        log.info('ice.config.js has been changed');
+        log.info(`${commandArgs.config || 'ice.config.js'} has been changed`);
         if (!server) {
           log.error('dev server is not ready');
         } else {


### PR DESCRIPTION
## 问题

自定义 config 参数时，更改配置文件内容，项目无法刷新

e.g.  `ice-scripts dev --config dev.ice.config.js` 

## 原因

 devWatcher 只检测了默认 `ice.config.js` 文件

```
if (command === 'dev') {
    // setup watch
    // check watcher in case of reRun plugins
    if (!watcher) {
      const configPath = path.resolve(rootDir, 'ice.config.js');
      watcher = chokidar.watch(configPath, {
        ignoreInitial: true,
      });
  }
}
```

