### PR TITLE
feat: support thread-loader

### DIFF
--- a/packages/ice-skin-loader/lib/index.js
+++ b/packages/ice-skin-loader/lib/index.js
@@ -10,13 +10,14 @@ let projectPkgData = null;
 
 module.exports = function (source) {
   const options = loaderUtils.getOptions(this);
+  const rootContext = this.rootContext || this.options.context;
 
   const { themeFile, themeConfig } = options;
-  const modulePath = path.relative(this.rootContext, this.resourcePath);
+  const modulePath = path.relative(rootContext, this.resourcePath);
 
   if (!projectPkgData) {
     try {
-      projectPkgData = require(path.resolve(this.rootContext, 'package.json'));
+      projectPkgData = require(path.resolve(rootContext, 'package.json'));
     } catch (err) {
       console.error(chalk.red('\n[Error] 读取 package.json 出错'), err);
       projectPkgData = {};


### PR DESCRIPTION
使用 thread-loader 抛出异常

```shell
Module build failed (from ./node_modules/_mini-css-extract-plugin@0.8.2@mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/_thread-loader@3.0.0@thread-loader/dist/cjs.js):
Thread Loader (Worker 5)
The "from" argument must be of type string. Received type undefined
    at PoolWorker.fromErrorObj (~/node_modules/_thread-loader@3.0.0@thread-loader/dist/WorkerPool.js:344:12)
    at ~/node_modules/_thread-loader@3.0.0@thread-loader/dist/WorkerPool.js:217:29
    at mapSeries (~/node_modules/_neo-async@2.6.2@neo-async/async.js:3625:14)
    at validateString (internal/validators.js:125:11)
    at Object.relative (path.js:1162:5)
    at Object.module.exports (~/node_modules/_ice-skin-loader@0.3.0@ice-skin-loader/lib/index.js:15:27)
```

兼容 rootContext